### PR TITLE
Update rewards for uncle miners for ECIP1017

### DIFF
--- a/ethcore/src/ethereum/ethash.rs
+++ b/ethcore/src/ethereum/ethash.rs
@@ -291,11 +291,19 @@ impl Engine for Arc<Ethash> {
 		// Bestow uncle rewards
 		let current_number = fields.header.number();
 		for u in fields.uncles.iter() {
-			fields.state.add_balance(
-				u.author(),
-				&(reward * U256::from(8 + u.number() - current_number) / U256::from(8)),
-				CleanupMode::NoEmpty
-			)?;
+			let res = if eras == 0 {
+				fields.state.add_balance(
+					u.author(),
+					&(reward * U256::from(8 + u.number() - current_number) / U256::from(8)),
+					CleanupMode::NoEmpty
+				)
+			} else {
+				fields.state.add_balance(
+					u.author(),
+					&(reward * / U256::from(32)),
+					CleanupMode::NoEmpty
+				)
+			}?;
 		}
 
 		// Commit state so that we can actually figure out the state root.


### PR DESCRIPTION
In the monetary policy, the rewards are changed from "up to 7/8 of the
reward" to "1/32 of the reward".