### PR TITLE
Fix an off-by-one error in ECIP1017 era calculation

### DIFF
--- a/ethcore/src/ethereum/ethash.rs
+++ b/ethcore/src/ethereum/ethash.rs
@@ -276,7 +276,11 @@ impl Engine for Arc<Ethash> {
 		let mut reward = self.ethash_params.block_reward;
 		let fields = block.fields_mut();
 
-		let eras = fields.header.number() / self.ethash_params.ecip1017_era_rounds;
+		let eras = if fields.header.number() != 0 && fields.header.number() % self.ethash_params.ecip1017_era_rounds == 0 {
+			fields.header.number() / self.ethash_params.ecip1017_era_rounds - 1
+		} else {
+			fields.header.number() / self.ethash_params.ecip1017_era_rounds
+		};
 		for _ in 0..eras {
 			reward = reward / U256::from(5) * U256::from(4);
 		}


### PR DESCRIPTION
According to
https://github.com/ethereumproject/ECIPs/blob/master/ECIPs/ECIP-1017.md,
when in block number 5,000,000, it should still be in Era 1 (which in
our code `era == 0`). So we need to check whether the `rem` equals to
zero and act accordingly when calculating the era.